### PR TITLE
Fix for bluetooth controllers and use Weston's kiosk mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+controller_blacklists
+profiles
+sway_configs
+steamos-check

--- a/Co-Op-On-Linux.sh
+++ b/Co-Op-On-Linux.sh
@@ -3,6 +3,7 @@
 DIR_CO_OP=$PWD
 DIR_CO_OP_WEST=$DIR_CO_OP/weston_configs
 DIR_CO_OP_CONT=$DIR_CO_OP/controller_blacklists
+DIR_CO_OP_SWAY=$DIR_CO_OP/sway_configs
 
 
 ### Currently only 2 players is supported 
@@ -53,13 +54,13 @@ CONTROLLER_2=$(zenity --list --title="Choose controller for player 2" --text="" 
 # add each device to blacklist
 for dev in $CONTROLLER_1
 do
-    printf -- '--blacklist=/dev/input/%s\n' $dev >> $DIR_CO_OP_CONT/Player1_Controller_Blacklist
+    printf -- '--blacklist=/dev/input/%s ' $dev >> $DIR_CO_OP_CONT/Player1_Controller_Blacklist
 done
 
 # add each device to blacklist
 for dev in $CONTROLLER_2
 do
-    printf -- '--blacklist=/dev/input/%s\n' $dev >> $DIR_CO_OP_CONT/Player2_Controller_Blacklist
+    printf -- '--blacklist=/dev/input/%s ' $dev >> $DIR_CO_OP_CONT/Player2_Controller_Blacklist
 done
 
 fi
@@ -93,7 +94,6 @@ cp $DIR_CO_OP_WEST/weston0.ini $DIR_CO_OP_WEST/weston1.ini
 cp $DIR_CO_OP_WEST/weston0.ini $DIR_CO_OP_WEST/weston2.ini
 fi
 
-
 ### Setup resolution for Weston sessions
 
 if [ "$1" = --quickrun ]; then
@@ -101,26 +101,50 @@ RESOLUTION=($2)
 else
 RESOLUTION=$(zenity --title="Resolution" --entry --text="Enter Resolution for Weston sessions ( for example: 1280x720 ) " --entry-text="1280x720")
 fi
+
 WIDTH=$(printf $RESOLUTION | awk -F "x" '{print $1}')
 HEIGHT=$(printf $RESOLUTION | awk -F "x" '{print $2}')
 
+exec_command1="WAYLAND_DISPLAY=wayland-2 firejail --noprofile $(cat $DIR_CO_OP_CONT/Player2_Controller_Blacklist ) $GAMERUN"
+exec_command2="WAYLAND_DISPLAY=wayland-2 firejail --noprofile $(cat $DIR_CO_OP_CONT/Player1_Controller_Blacklist ) $GAMERUN"
+
+mkdir $DIR_CO_OP_SWAY
+rm $DIR_CO_OP_SWAY/*.conf
+
+echo "default_border none 0" > $DIR_CO_OP_SWAY/sway0.conf
+echo "output WL-1 resolution $(($WIDTH*2))x$HEIGHT" >> $DIR_CO_OP_SWAY/sway0.conf
+echo "exec sway -c $DIR_CO_OP_SWAY/sway1.conf" >> $DIR_CO_OP_SWAY/sway0.conf
+echo "exec sway -c $DIR_CO_OP_SWAY/sway2.conf" >> $DIR_CO_OP_SWAY/sway0.conf
+
+echo "default_border none 0" > $DIR_CO_OP_SWAY/sway1.conf
+echo "output WL-1 resolution $(($WIDTH))x$HEIGHT" >> $DIR_CO_OP_SWAY/sway1.conf
+echo "exec $exec_command1" >> $DIR_CO_OP_SWAY/sway1.conf
+
+echo "default_border none 0" > $DIR_CO_OP_SWAY/sway2.conf
+echo "output WL-1 resolution $(($WIDTH))x$HEIGHT" >> $DIR_CO_OP_SWAY/sway2.conf
+echo "exec $exec_command2" >> $DIR_CO_OP_SWAY/sway2.conf
 
 ### Launching Weston sessions
-weston --xwayland -c "$DIR_CO_OP_WEST/weston1.ini" --width=$WIDTH --height=$HEIGHT 2> /dev/null &
-weston --xwayland -c "$DIR_CO_OP_WEST/weston2.ini" --width=$WIDTH --height=$HEIGHT 2> /dev/null &
+#weston --xwayland -c "$DIR_CO_OP_WEST/weston1.ini" --width=$WIDTH --height=$HEIGHT 2> /dev/null &
+#weston --xwayland -c "$DIR_CO_OP_WEST/weston2.ini" --width=$WIDTH --height=$HEIGHT 2> /dev/null &
+
+### Launching sway sessions
+
+sway -c $DIR_CO_OP_SWAY/sway0.conf &
+
+#WAYLAND_DISPLAY=wayland-1 sway -c $DIR_CO_OP_SWAY/sway1.conf &
+#WAYLAND_DISPLAY=wayland-1 sway -c $DIR_CO_OP_SWAY/sway2.conf &
+
 #notneeded=$(ps l | grep weston0.ini | awk 'length($0) > 120 {print $3}')
 #kill $notneeded
-sleep 1
-
-
-### Launching instances
+sleep 3
 
 #---Player 1---#
 #sleep 5
-DISPLAY=:2 WAYLAND_DISPLAY=wayland-1 firejail --noprofile $(cat $DIR_CO_OP_CONT/Player2_Controller_Blacklist ) "$GAMERUN" &
+#DISPLAY=:3 WAYLAND_DISPLAY=wayland-2 firejail --noprofile $(cat $DIR_CO_OP_CONT/Player2_Controller_Blacklist ) "$GAMERUN" &
 #sleep 1
 #---Player 2---#
-DISPLAY=:3 WAYLAND_DISPLAY=wayland-2 firejail --noprofile $(cat $DIR_CO_OP_CONT/Player1_Controller_Blacklist ) "$GAMERUN" &
+#DISPLAY=:4 WAYLAND_DISPLAY=wayland-3 firejail --noprofile $(cat $DIR_CO_OP_CONT/Player1_Controller_Blacklist ) "$GAMERUN" &
 #sleep 1
 
 

--- a/Co-Op-On-Linux.sh.md5
+++ b/Co-Op-On-Linux.sh.md5
@@ -1,1 +1,0 @@
-08d59f8a0a8fd69a2cf4ddbbdedd3606

--- a/create-new-preset.sh
+++ b/create-new-preset.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env sh
+#
+DIALOG=zenity
+DIR_CO_OP=$PWD
+
+if type "kdialog" > /dev/null; then
+    GAMERUN=$(kdialog --title="Select game executable/launch script" --getopenfilename)
+else
+    GAMERUN=$(zenity --title="Select game executable/launch script" --file-selection)
+fi
+
+DEFAULT_RES=$(xdpyinfo | awk '/dimensions/{print $2}')
+RESOLUTION=$($DIALOG --title="Resolution" --entry --text="Enter Resolution for Weston sessions ( for example: 1280x720 ) " --entry-text=$DEFAULT_RES)
+
+WIDTH=$(printf $RESOLUTION | awk -F "x" '{print $1}')
+HEIGHT=$(printf $RESOLUTION | awk -F "x" '{print $2}')
+
+name=$($DIALOG --title="Profile name" --entry --text="Enter a name for the profile" --entry-text="name")
+mkdir -p $DIR_CO_OP/profiles
+echo "export WIDTH=$WIDTH" > "$DIR_CO_OP/profiles/$name.sh"
+echo "export HEIGHT=$HEIGHT" >> "$DIR_CO_OP/profiles/$name.sh"
+echo "export GAMERUN='$GAMERUN'" >> "$DIR_CO_OP/profiles/$name.sh"
+echo "../Co-Op-On-Linux.sh" >> "$DIR_CO_OP/profiles/$name.sh"
+chmod +x "$DIR_CO_OP/profiles/$name.sh"
+
+zenity --info --text "Preset created! To load it go to the preset folder and execute it's script"

--- a/get-devices.py
+++ b/get-devices.py
@@ -28,17 +28,17 @@ for i in range(0, len(lines)):
         devices.append(lines[i][9:-2])
         devhandlers = []
 
-        syspath = lines[i+2][9:]
+        syspath = "/sys" + lines[i+2][9:]
         p = Path(syspath)
         p = p.parent.parent / "hidraw"
         if (p.exists()):
-            for i in p.iterdir():
-                devhandlers.append("/dev/"+i.name)
+            for a in p.iterdir():
+                devhandlers.append("/dev/"+a.name)
 
-        for h in lines[i+4][12:-1].split(" "):
-            devhandlers.append("/dev/input"+h)
+        for h in lines[i+4][12:-2].split(" "):
+            devhandlers.append("/dev/input/"+h)
 
-        handlers.append(devhandlers.join(" "))
+        handlers.append(" ".join(devhandlers))
 
 if sys.argv[1] == "list-handlers-exclude":
     for a in range(2, len(sys.argv)):
@@ -49,7 +49,8 @@ if sys.argv[1] == "list-handlers-exclude":
 
 
     for i in range(0, len(handlers)):
-        print(handlers[i])
+        print(handlers[i], end=" ")
+    print("\n", end="")
 
 if sys.argv[1] == "list-handlers":
     for i in range(0, len(handlers)):

--- a/get-devices.py
+++ b/get-devices.py
@@ -1,4 +1,19 @@
+#!/usr/bin/env python
+
 import sys
+from pathlib import Path
+
+if len(sys.argv) < 2 or sys.argv[1] == "help":
+    print("""get-devices.py usage
+
+help: Display this help
+list-handlers: list all gamepad handlers
+list-names: list all gamepad names
+list-zenity: list all gamepad handlers and names on a format for zenity (Each line it displays name and the next, handler)
+list-zenity-exclude <handlers...>: like list-zenity but excludes the devices with the specified handlers
+list-handlers-exclude <handlers...>: list all gamepad handlers excluding the ones specified on the command arguments
+    """)
+    exit()
 
 f = open("/proc/bus/input/devices", "r")
 
@@ -11,8 +26,48 @@ for i in range(0, len(lines)):
     if (lines[i][0] == 'N'):
         if ("js" not in lines[i+4]): continue
         devices.append(lines[i][9:-2])
-        handlers.append(lines[i+4][12:-1])
+        devhandlers = []
 
-for i in range(0, len(devices)):
-    print(devices[i])
-    print(handlers[i])
+        syspath = lines[i+2][9:]
+        p = Path(syspath)
+        p = p.parent.parent / "hidraw"
+        if (p.exists()):
+            for i in p.iterdir():
+                devhandlers.append("/dev/"+i.name)
+
+        for h in lines[i+4][12:-1].split(" "):
+            devhandlers.append("/dev/input"+h)
+
+        handlers.append(devhandlers.join(" "))
+
+if sys.argv[1] == "list-handlers-exclude":
+    for a in range(2, len(sys.argv)):
+        for i in range(0, len(handlers)):
+            if (i > len(handlers)-1): break
+            if sys.argv[a] in handlers[i]:
+                del handlers[i]
+
+
+    for i in range(0, len(handlers)):
+        print(handlers[i])
+
+if sys.argv[1] == "list-handlers":
+    for i in range(0, len(handlers)):
+        print(handlers[i])
+
+if sys.argv[1] == "list-names":
+    for i in range(0, len(devices)):
+        print(devices[i])
+
+if sys.argv[1] == "list-zenity" or sys.argv[1] == "list-zenity-exclude":
+    if sys.argv[1] == "list-zenity-exclude":
+        for a in range(2, len(sys.argv)):
+            for i in range(0, len(handlers)):
+                if (i > len(handlers)-1): break
+                if sys.argv[a] in handlers[i]:
+                    del handlers[i]
+                    del devices[i]
+
+    for i in range(0, len(devices)):
+        print(devices[i])
+        print(handlers[i])

--- a/get-devices.py
+++ b/get-devices.py
@@ -1,0 +1,18 @@
+import sys
+
+f = open("/proc/bus/input/devices", "r")
+
+lines = f.readlines()
+
+devices = []
+handlers = []
+
+for i in range(0, len(lines)):
+    if (lines[i][0] == 'N'):
+        if ("js" not in lines[i+4]): continue
+        devices.append(lines[i][9:-2])
+        handlers.append(lines[i+4][12:-1])
+
+for i in range(0, len(devices)):
+    print(devices[i])
+    print(handlers[i])

--- a/install-steamos.sh
+++ b/install-steamos.sh
@@ -36,6 +36,8 @@ fi
 
 sudo steamos-readonly disable
 
+sudo pacman-key --init
+sudo pacman-key --populate archlinux holo
 sudo pacman -S sway firejail
 
 sudo steamos-readonly enable

--- a/install-steamos.sh
+++ b/install-steamos.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env sh
+
+echo "Welcome to the Co-op-on-Linux SteamOS installer!
+Please be warned that this installer will install some packages to the system (sway and firejail),
+the packages may be wiped when a SteamOS update occurs, the installer will leave a flag on the program's directory
+to check for this and re-run the installer
+"
+while true; do
+    read -p "Do you wish to to continue [Yn] " yn
+    case $yn in
+        [Yy]* ) break;;
+        [Nn]* ) exit;;
+    esac
+
+    if [ -z $yn ]; then
+        break
+    fi
+done
+
+if [[ "$(passwd --status)" =~ "NP" ]]; then
+    echo "You have not set a sudo password. This is required for installation"
+    while true; do
+        read -p "Do you want to setup a sudo password" yn
+        case $yn in
+            [Yy]* ) break;;
+            [Nn]* ) exit;;
+        esac
+
+        if [ -z $yn ]; then
+            break
+        fi
+    done
+
+    passwd
+fi
+
+sudo steamos-readonly disable
+
+sudo pacman -S sway firejail
+
+sudo steamos-readonly enable
+
+echo "1" >> steamos-check
+
+read -p "Installation finished! Press Enter to finish "


### PR DESCRIPTION
I have modified the script to use a python script I made that reads `/proc/bus/input/devices` to get the devices and handlers of the controllers. This is because the `/dev/input/by-id` approach only works for controllers connected via usb. This method works for both

Also, it now uses Weston's kiosk mode, this way the background is black without anything else on screen other than the game; I would have liked to implement gamescope but right now it doesn't work on my dev machine.

(Btw, I've reversed the way that the blacklist files work, instead of blacklisting the other gamepad, it blacklists that gamepad. This way we can, in the future, append the files to only whitelist the gamepad we want if we have more than 2 gamepads)